### PR TITLE
MPL-22 Fixed issue with allowed methods override by global vars

### DIFF
--- a/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestHelper.groovy
+++ b/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestHelper.groovy
@@ -33,4 +33,10 @@ class MPLTestHelper extends PipelineTestHelper {
   public getLibraryClassLoader() {
     gse.groovyClassLoader
   }
+  
+  void registerAllowedMethod(MethodSignature methodSignature, Closure closure) {
+    if( isMethodAllowed(methodSignature.name, methodSignature.args) )
+      return // Skipping methods already existing in the list
+    allowedMethodCallbacks.put(methodSignature, closure)
+  }
 }


### PR DESCRIPTION
Simple change to make sure mocks `allowed methods` will never be replaced by the `global vars` automatically and always will have top priority.

Closes #22