### PR TITLE
MPL-52 Fix for issue with restore of the MPL state after restart (#52)

### DIFF
--- a/src/com/griddynamics/devops/mpl/MPLManager.groovy
+++ b/src/com/griddynamics/devops/mpl/MPLManager.groovy
@@ -23,13 +23,29 @@
 
 package com.griddynamics.devops.mpl
 
+import com.cloudbees.groovy.cps.NonCPS
+
+import com.griddynamics.devops.mpl.MPLException
+import com.griddynamics.devops.mpl.MPLConfig
+import com.griddynamics.devops.mpl.Helper
+
 /**
  * Object to help with MPL pipelines configuration & poststeps
  *
  * @author Sergei Parshev <sparshev@griddynamics.com>
  */
-@Singleton
 class MPLManager implements Serializable {
+  /**
+   * Simple realization of a singleton
+   */
+  private static inst = null
+
+  public static getInstance() {
+    if( ! inst )
+      inst = new MPLManager()
+    return inst
+  }
+
   /** List of paths which is used to find modules in libraries */
   private List modulesLoadPaths = ['com/griddynamics/devops/mpl']
 
@@ -245,5 +261,23 @@ class MPLManager implements Serializable {
    */
   public popActiveModule() {
     activeModules.pop()
+  }
+
+  /**
+   * Restore the static object state if the pipeline was interrupted
+   *
+   * This function helps to make sure the MPL object will be restored
+   * if jenkins was restarted during the pipeline execution. It will
+   * work if the MPL object is stored in the pipeline:
+   *
+   * var/MPLPipeline.groovy:
+   *   ...
+   *   def MPL = MPLPipelineConfig(body, [
+   *   ...
+   */
+  @NonCPS
+  private void readObject(java.io.ObjectInputStream inp) throws IOException, ClassNotFoundException {
+    inp.defaultReadObject()
+    inst = this
   }
 }


### PR DESCRIPTION
Used Serializable readObject to restore the static class instance state.
The one issue was fixed using @NonCPS.

This fix requires MPL object to be stored in the pipeline (as in [vars/MPLPipeline#31](/griddynamics/mpl/blob/0226587/vars/MPLPipeline.groovy#L31)).

fixes #52 