### PR TITLE
MPL-54 Fix for pipeline MPLModules parallelization (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ When error occurs during poststeps execution - it will be printed in the log, bu
    MPLPostStep('always') {
      echo "OpenShift Deploy Decomission poststep"
    }
- 
+
    echo 'Executing Openshift Deploy process'
    ```
 2. `{NestedLib}/var/CustomPipeline.groovy`:
@@ -316,7 +316,7 @@ We fine with standard pipeline, but would like to use different deploy stage.
 * `{ProjectRepo}/Jenkinsfile`:
   ```
   @Library('mpl@release') _
-  
+
   // Use default master pipeline
   MPLPipeline {}
   ```
@@ -324,10 +324,10 @@ We fine with standard pipeline, but would like to use different deploy stage.
   ```
   // Any step could be here, config modification, etc.
   echo "Let's begin the deployment process!"
-  
+
   // Run original deployment from the library
   MPLModule('Deploy', CFG)
-  
+
   echo "Deployment process completed!"
   ```
 

--- a/src/com/griddynamics/devops/mpl/Helper.groovy
+++ b/src/com/griddynamics/devops/mpl/Helper.groovy
@@ -139,11 +139,9 @@ abstract class Helper {
    */
   @NonCPS
   static Boolean pathExists(String path) {
-    return CpsThread.current().getContextVariable(
-      FilePath.class,
-      CpsThread.current().&getExecution,
-      CpsThread.current().head.&get
-    )?.child(path)?.exists()
+    return CpsThread.current() ? CpsThread.current().getContextVariable(
+      FilePath.class, CpsThread.current().&getExecution, CpsThread.current().head.&get
+    )?.child(path)?.exists() : null
   }
 
   /**
@@ -156,11 +154,9 @@ abstract class Helper {
    */
   @NonCPS
   static String pathRead(String path) {
-    return CpsThread.current().getContextVariable(
-      FilePath.class,
-      CpsThread.current().&getExecution,
-      CpsThread.current().head.&get
-    )?.child(path)?.read()?.toString()
+    return CpsThread.current() ? CpsThread.current().getContextVariable(
+      FilePath.class, CpsThread.current().&getExecution, CpsThread.current().head.&get
+    )?.child(path)?.read()?.toString() : null
   }
 
   /**

--- a/src/com/griddynamics/devops/mpl/Helper.groovy
+++ b/src/com/griddynamics/devops/mpl/Helper.groovy
@@ -29,10 +29,15 @@ import com.cloudbees.groovy.cps.NonCPS
 
 import org.jenkinsci.plugins.workflow.cps.CpsGroovyShellFactory
 import org.jenkinsci.plugins.workflow.cps.CpsThread
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode
+import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode
+import org.jenkinsci.plugins.workflow.actions.LabelAction
+import org.jenkinsci.plugins.workflow.cps.actions.ArgumentsActionImpl
 import org.jenkinsci.plugins.workflow.libs.LibrariesAction
 
 import hudson.model.Run
 import hudson.FilePath
+import jenkins.model.Jenkins
 
 /**
  * Manages all helpers to interact with low-level groovy
@@ -44,6 +49,7 @@ abstract class Helper {
    * Get a new shell with set some specific variables
    *
    * @param vars  Predefined variables to include in the shell
+   *
    * @return  cps groovy shell object
    */
   @NonCPS
@@ -59,6 +65,7 @@ abstract class Helper {
    * Idea from LibraryAdder.findResource() function
    *
    * @param path  Module resource path
+   *
    * @return  list of maps with pairs "module path: module source code"
    *
    * @see org.jenkinsci.plugins.workflow.libs.LibraryAdder#findResources(CpsFlowExecution execution, String name)
@@ -89,6 +96,7 @@ abstract class Helper {
    *
    * @param base     map for modification
    * @param overlay  map to override values in the _base_ map
+   *
    * @return  modified base map
    */
   static Map mergeMaps(Map base, Map overlay) {
@@ -119,6 +127,103 @@ abstract class Helper {
       out = value
 
     return out
+  }
+
+  /**
+   * Silently check the workspace file existence
+   * Quiet version of fileExists step
+   *
+   * @param path  relative path to the file in workspace
+   *
+   * @return  Boolean if file exists or not or null if there is no workspace available
+   */
+  @NonCPS
+  static Boolean pathExists(String path) {
+    return CpsThread.current().getContextVariable(
+      FilePath.class,
+      CpsThread.current().&getExecution,
+      CpsThread.current().head.&get
+    )?.child(path)?.exists()
+  }
+
+  /**
+   * Silently read the workspace file
+   * Quiet version of readFile step
+   *
+   * @param path  relative path to the file in workspace
+   *
+   * @return  String with the file content
+   */
+  @NonCPS
+  static String pathRead(String path) {
+    return CpsThread.current().getContextVariable(
+      FilePath.class,
+      CpsThread.current().&getExecution,
+      CpsThread.current().head.&get
+    )?.child(path)?.read()?.toString()
+  }
+
+  /**
+   * Returns just last two components of the path without an extension
+   *
+   * @param path  resource path of the module
+   *
+   * @return  String simple MPL module name
+   */
+  @NonCPS
+  static String pathToSimpleName(String path) {
+    return path.tokenize('./')[-3,-2].join('/')
+  }
+
+  /**
+   * Starts block for the MPL module
+   *
+   * @param path  resource path of the module to track it
+   *
+   * @return  String block id (used for tests)
+   */
+  @NonCPS
+  static String startMPLBlock(String path) {
+    def node = new StepStartNode(
+      CpsThread.current().getExecution(),
+      Jenkins.get().getDescriptor('org.jenkinsci.plugins.workflow.steps.EchoStep'),
+      CpsThread.current().head.get()
+    )
+    node.addAction(new LabelAction("MPL: ${pathToSimpleName(path)}"))
+    node.addAction(new ArgumentsActionImpl([MPLModule:path]))
+    CpsThread.current().head.setNewHead(node)
+
+    return node.getId()
+  }
+
+  /**
+   * Ends the current MPL module block
+   *
+   * @param start_id  start node ID to find in the current execution (used for tests)
+   */
+  @NonCPS
+  static void endMPLBlock(String start_id = null) {
+    CpsThread.current().head.setNewHead(new StepEndNode(
+      CpsThread.current().getExecution(),
+      CpsThread.current().getExecution().getNode(getMPLBlocks().first().id),
+      CpsThread.current().head.get()
+    ))
+  }
+
+  /**
+   * Returns stack of the running modules
+   * The first one - is the current one
+   *
+   * @return  List with maps, contains module name and id
+   */
+  @NonCPS
+  static List getMPLBlocks() {
+    def nodes = [CpsThread.current().head.get()]
+    nodes += nodes.first().getEnclosingBlocks()
+    return nodes.collect {[
+      id: it.getId(),
+      module: it.getPersistentAction(ArgumentsActionImpl.class)?.getArgumentValue('MPLModule'),
+    ]}.findAll{ it.module }
   }
 
   /**

--- a/src/com/griddynamics/devops/mpl/MPLConfig.groovy
+++ b/src/com/griddynamics/devops/mpl/MPLConfig.groovy
@@ -85,7 +85,7 @@ public class MPLConfig implements Map, Serializable {
   public int size() { this.@config.size() }
   public boolean isEmpty() { this.@config.isEmpty() }
   public Set entrySet() { Helper.configEntrySet(this.@config) }
-  
+
   /**
    * Get a value copy of the provided config key path
    *

--- a/src/com/griddynamics/devops/mpl/MPLManager.groovy
+++ b/src/com/griddynamics/devops/mpl/MPLManager.groovy
@@ -259,7 +259,7 @@ class MPLManager implements Serializable {
    *
    * @param path  Path to the module (including library if it's the library)
    *
-   * @return  String block id (used for tests)
+   * @return  String the created block id
    */
   public String pushActiveModule(String path) {
     return Helper.startMPLBlock(path)
@@ -268,9 +268,9 @@ class MPLManager implements Serializable {
   /**
    * Removing the latest active module from the list
    *
-   * @param start_id  start node ID to find in the current execution (used for tests)
+   * @param start_id  start node ID to find in the current execution
    */
-  public void popActiveModule(String start_id = null) {
+  public void popActiveModule(String start_id) {
     Helper.endMPLBlock(start_id)
   }
 }

--- a/src/com/griddynamics/devops/mpl/MPLManager.groovy
+++ b/src/com/griddynamics/devops/mpl/MPLManager.groovy
@@ -51,13 +51,11 @@ class MPLManager implements Serializable {
   /** List of modules available on project side while enforcement */
   private List enforcedModules = []
 
-  /** List of currently executed modules */
-  private List activeModules = []
-
   /**
    * Initialization for the MPL manager
    *
    * @param pipelineConfig  Map with common configuration and specific modules configs
+   *
    * @return  MPLManager singleton object
    */
   public init(pipelineConfig = null) {
@@ -90,6 +88,7 @@ class MPLManager implements Serializable {
    * Determine is module exists in the configuration or not
    *
    * @param name  module name
+   *
    * @return  Boolean about existing the module
    */
   public Boolean moduleEnabled(String name) {
@@ -109,19 +108,23 @@ class MPLManager implements Serializable {
   public void postStep(String name, Closure body) {
     // TODO: Parallel execution - could be dangerous
     if( ! postSteps[name] ) postSteps[name] = []
-    postSteps[name] << [module: getActiveModules()?.last(), body: body]
+    postSteps[name] << [block: Helper.getMPLBlocks()?.first(), body: body]
   }
 
   /**
    * Add module post step to the list
    *
-   * @param name  Module poststeps list name
+   * @param name  Module poststeps list name (default: current "module(id)")
    * @param body  Definition of steps to include in the list
    */
   public void modulePostStep(String name, Closure body) {
+    if( name == null ) {
+      def block = Helper.getMPLBlocks().first()
+      name = "${block.module}(${block.id})"
+    }
     // TODO: Parallel execution - could be dangerous
     if( ! modulePostSteps[name] ) modulePostSteps[name] = []
-    modulePostSteps[name] << [module: getActiveModules()?.last(), body: body]
+    modulePostSteps[name] << [block: Helper.getMPLBlocks()?.first(), body: body]
   }
 
   /**
@@ -133,10 +136,11 @@ class MPLManager implements Serializable {
     if( postSteps[name] ) {
       for( def i = postSteps[name].size()-1; i >= 0 ; i-- ) {
         try {
-          postSteps[name][i]['body']()
+          postSteps[name][i].body()
         }
         catch( ex ) {
-          postStepError(name, postSteps[name][i]['module'], ex)
+          def module_name = "${modulePostSteps[name][i].block?.module}(${modulePostSteps[name][i].block?.id})"
+          postStepError(name, module_name, ex)
         }
       }
     }
@@ -145,16 +149,21 @@ class MPLManager implements Serializable {
   /**
    * Execute module post steps filled by module in reverse order
    *
-   * @param name  Module poststeps list name
+   * @param name  Module poststeps list name (default: current "module(id)")
    */
-  public void modulePostStepsRun(String name) {
+  public void modulePostStepsRun(String name = null) {
+    if( name == null ) {
+      def block = Helper.getMPLBlocks().first()
+      name = "${block.module}(${block.id})"
+    }
     if( modulePostSteps[name] ) {
       for( def i = modulePostSteps[name].size()-1; i >= 0 ; i-- ) {
         try {
-          modulePostSteps[name][i]['body']()
+          modulePostSteps[name][i].body()
         }
         catch( ex ) {
-          postStepError(name, modulePostSteps[name][i]['module'], ex)
+          def module_name = "${modulePostSteps[name][i].block?.module}(${modulePostSteps[name][i].block?.id})"
+          postStepError(name, module_name, ex)
         }
       }
     }
@@ -171,14 +180,19 @@ class MPLManager implements Serializable {
     if( ! postStepsErrors[name] ) postStepsErrors[name] = []
     postStepsErrors[name] << [module: module, error: exception]
   }
-  
+
   /**
    * Get the list of errors become while poststeps execution
    *
-   * @param name  Poststeps list name
+   * @param name  Poststeps list name (default: current "module(id)")
+   *
    * @return  List of errors
    */
-  public List getPostStepsErrors(String name) {
+  public List getPostStepsErrors(String name = null) {
+    if( name == null ) {
+      def block = Helper.getMPLBlocks().first()
+      name = "${block.module}(${block.id})"
+    }
     postStepsErrors[name] ?: []
   }
 
@@ -224,26 +238,39 @@ class MPLManager implements Serializable {
 
   /**
    * Get list of currently executing modules
+   * Last item is the current one
    *
    * @return  List of modules paths
+   *
+   * @deprecated - old function, now works with the current thread, but it's
+   *               better to switch to Helper.getMPLBlocks() - it gives more
+   *               info about the currently executed modules
    */
-  public getActiveModules() {
-    activeModules
+  @Deprecated // https://github.com/griddynamics/mpl/issues/54
+  public List getActiveModules() {
+    def blocks = Helper.getMPLBlocks()
+    for( def i = 0; i < blocks.size(); i++ )
+      blocks[i] = blocks[i].module
+    return blocks.reverse()
   }
 
   /**
    * Add active module to the stack-list
    *
    * @param path  Path to the module (including library if it's the library)
+   *
+   * @return  String block id (used for tests)
    */
-  public pushActiveModule(String path) {
-    activeModules += path
+  public String pushActiveModule(String path) {
+    return Helper.startMPLBlock(path)
   }
 
   /**
    * Removing the latest active module from the list
+   *
+   * @param start_id  start node ID to find in the current execution (used for tests)
    */
-  public popActiveModule() {
-    activeModules.pop()
+  public void popActiveModule(String start_id = null) {
+    Helper.endMPLBlock(start_id)
   }
 }

--- a/test/groovy/com/griddynamics/devops/mpl/modules/Build/BuildTest.groovy
+++ b/test/groovy/com/griddynamics/devops/mpl/modules/Build/BuildTest.groovy
@@ -73,20 +73,21 @@ class BuildTest extends MPLTestBase {
     assertThat(helper.callStack)
       .filteredOn { c -> c.methodName == 'tool' }
       .filteredOn { c -> c.argsToString().contains('Maven 3') }
+      .as('Maven 3 tool used')
       .isNotEmpty()
 
     assertThat(helper.callStack)
-      .as('Shell execution should contain mvn command and default clean install')
       .filteredOn { c -> c.methodName == 'sh' }
       .filteredOn { c -> c.argsToString().startsWith('mvn') }
       .filteredOn { c -> c.argsToString().contains('clean install') }
+      .as('Shell execution should contain mvn command and default clean install')
       .isNotEmpty()
 
     assertThat(helper.callStack)
-      .as('Default mvn run without settings provided')
       .filteredOn { c -> c.methodName == 'sh' }
       .filteredOn { c -> c.argsToString().startsWith('mvn') }
       .filteredOn { c -> ! c.argsToString().contains('-s ') }
+      .as('Default mvn run without settings provided')
       .isNotEmpty()
 
     assertJobStatusSuccess()
@@ -103,9 +104,9 @@ class BuildTest extends MPLTestBase {
     printCallStack()
 
     assertThat(helper.callStack)
-      .as('Changing maven tool name')
       .filteredOn { c -> c.methodName == 'tool' }
       .filteredOn { c -> c.argsToString().contains('Maven 2') }
+      .as('Changing maven tool name')
       .isNotEmpty()
 
     assertJobStatusSuccess()
@@ -122,9 +123,9 @@ class BuildTest extends MPLTestBase {
     printCallStack()
 
     assertThat(helper.callStack)
-      .as('Providing setings file should set the maven opetion')
       .filteredOn { c -> c.methodName == 'sh' }
       .filteredOn { c -> c.argsToString().contains("-s '/test-settings.xml'") }
+      .as('Providing setings file should set the maven operation')
       .isNotEmpty()
 
     assertJobStatusSuccess()

--- a/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestBase.groovy
+++ b/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestBase.groovy
@@ -23,6 +23,8 @@
 
 package com.griddynamics.devops.mpl.testing
 
+import org.junit.AfterClass
+import org.junit.Before
 import com.lesfurets.jenkins.unit.BasePipelineTest
 
 import com.griddynamics.devops.mpl.MPLConfig
@@ -45,9 +47,8 @@ abstract class MPLTestBase extends BasePipelineTest {
   Map mpl_blocks = [:]
   int mpl_blocks_id_counter = 0
 
-  void setUp() throws Exception {
-    super.setUp()
-
+  @Before
+  void setupOverrides() {
     // Overriding Helper to find the right resources in the loaded libs
     Helper.metaClass.static.getModulesList = { String path ->
       def modules = []
@@ -96,13 +97,18 @@ abstract class MPLTestBase extends BasePipelineTest {
       ]
       return id.toString()
     }
-    Helper.metaClass.static.endMPLBlock = { String start_id = null ->
+    Helper.metaClass.static.endMPLBlock = { String start_id ->
       mpl_blocks[start_id.toInteger()].ended = true
     }
     Helper.metaClass.static.getMPLBlocks = { ->
       def level = getMPLModuleLevel()
       return findBlockParents(level)
     }
+  }
+
+  @AfterClass
+  static void cleanOverrides() {
+    GroovySystem.metaClassRegistry.removeMetaClass(Helper.class)
   }
 
   // Using stacktrace to determine the nesting level of the module

--- a/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestBase.groovy
+++ b/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestBase.groovy
@@ -33,10 +33,17 @@ import java.security.AccessController
 import java.security.PrivilegedAction
 import org.codehaus.groovy.runtime.InvokerHelper
 
+/**
+ * Reinitialized for each particular test
+ */
 abstract class MPLTestBase extends BasePipelineTest {
   MPLTestBase() {
     helper = new MPLTestHelper()
   }
+
+  // Contains all the executing blocks {id => [module, parent]}
+  Map mpl_blocks = [:]
+  int mpl_blocks_id_counter = 0
 
   void setUp() throws Exception {
     super.setUp()
@@ -72,8 +79,50 @@ abstract class MPLTestBase extends BasePipelineTest {
       script.metaClass.methodMissing = helper.getMethodMissingInterceptor()
       script.run()
     }
-    
+
     // Show the dump of the configuration during unit tests execution
     Helper.metaClass.static.configEntrySet = { Map config -> config.entrySet() }
+
+    // TODO: Not working properly with the parallel run
+    Helper.metaClass.static.startMPLBlock = { String path ->
+      def id = mpl_blocks_id_counter++
+      def level = getMPLModuleLevel()
+      mpl_blocks[id] = [
+        id: id,
+        module: path,
+        level: level,
+        ended: false,
+        parent: level > 1 ? findBlockParents(level-1).first().id : null,
+      ]
+      return id.toString()
+    }
+    Helper.metaClass.static.endMPLBlock = { String start_id = null ->
+      mpl_blocks[start_id.toInteger()].ended = true
+    }
+    Helper.metaClass.static.getMPLBlocks = { ->
+      def level = getMPLModuleLevel()
+      return findBlockParents(level)
+    }
+  }
+
+  // Using stacktrace to determine the nesting level of the module
+  int getMPLModuleLevel() {
+    return new Throwable().getStackTrace().findAll {
+      it.getClassName() == 'MPLModule' && it.getLineNumber() > -1
+    }.size()
+  }
+
+  // Get the list of the currently active modules of specified level and it's parents
+  List findBlockParents(int level) {
+    def curr_heads = mpl_blocks.values().findAll { it.ended == false && it.level == level }
+
+    if( curr_heads.size() == 0 )
+      return []
+    else if( curr_heads.size() > 1 )
+      throw Exception("Invalid number of current heads: ${curr_heads.size()} - unable to determine the current one")
+
+    for( def l = 0; l < level; l++ )
+      curr_heads += [mpl_blocks[curr_heads.last().parent]]
+    return curr_heads
   }
 }

--- a/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestHelper.groovy
+++ b/test/groovy/com/griddynamics/devops/mpl/testing/MPLTestHelper.groovy
@@ -34,7 +34,7 @@ class MPLTestHelper extends PipelineTestHelper {
   public getLibraryClassLoader() {
     gse.groovyClassLoader
   }
-  
+
   void registerAllowedMethod(MethodSignature methodSignature, Closure closure) {
     if( isMethodAllowed(methodSignature.name, methodSignature.args) )
       return // Skipping methods already existing in the list

--- a/vars/MPLModule.groovy
+++ b/vars/MPLModule.groovy
@@ -61,7 +61,6 @@ def call(String name = env.STAGE_NAME, cfg = null) {
   // Reading module definition from workspace or from the library resources
   def module_src = null
   if( MPLManager.instance.checkEnforcedModule(name)
-      && env.NODE_NAME != null
       && Helper.pathExists(project_path)
       && (! active_modules.contains(project_path)) ) {
     module_path = project_path

--- a/vars/MPLModule.groovy
+++ b/vars/MPLModule.groovy
@@ -50,6 +50,7 @@ def call(String name = env.STAGE_NAME, cfg = null) {
   
   // Trace of the running modules to find loops
   // Also to make ability to use lib module from overridden one
+  // TODO: replace getActiveModules() to Helper.getMPLBlocks()
   def active_modules = MPLManager.instance.getActiveModules()
 
   // Determining the module source file and location
@@ -59,9 +60,12 @@ def call(String name = env.STAGE_NAME, cfg = null) {
 
   // Reading module definition from workspace or from the library resources
   def module_src = null
-  if( MPLManager.instance.checkEnforcedModule(name) && env.NODE_NAME != null && fileExists(project_path) && (! active_modules.contains(project_path)) ) {
+  if( MPLManager.instance.checkEnforcedModule(name)
+      && env.NODE_NAME != null
+      && Helper.pathExists(project_path)
+      && (! active_modules.contains(project_path)) ) {
     module_path = project_path
-    module_src = readFile(project_path)
+    module_src = Helper.pathRead(project_path)
   } else {
     // Searching for the not executed module from the loaded libraries
     module_src = Helper.getModulesList(module_path).find { it ->
@@ -73,8 +77,9 @@ def call(String name = env.STAGE_NAME, cfg = null) {
   if( ! module_src )
     throw new MPLModuleException("Unable to find not active module to execute: ${(active_modules).join(' --> ')} -X> ${module_path}")
 
+  // Basically block_id is needed only for tests
+  String block_id = MPLManager.instance.pushActiveModule(module_path)
   try {
-    MPLManager.instance.pushActiveModule(module_path)
     Helper.runModule(module_src, module_path, [CFG: cfg])
   }
   catch( FlowInterruptedException ex ) {
@@ -88,8 +93,8 @@ def call(String name = env.STAGE_NAME, cfg = null) {
     throw newex
   }
   finally {
-    MPLManager.instance.modulePostStepsRun(module_path)
-    def errors = MPLManager.instance.getPostStepsErrors(module_path)
+    MPLManager.instance.modulePostStepsRun()
+    def errors = MPLManager.instance.getPostStepsErrors()
     if( errors ) {
       for( def e in errors )
         println "Module '${name}' got error during execution of poststep from module '${e.module}': ${e.error}"
@@ -97,6 +102,6 @@ def call(String name = env.STAGE_NAME, cfg = null) {
       newex.setStackTrace(Helper.getModuleStack(newex))
       throw newex
     }
-    MPLManager.instance.popActiveModule()
+    MPLManager.instance.popActiveModule(block_id)
   }
 }

--- a/vars/MPLModule.groovy
+++ b/vars/MPLModule.groovy
@@ -76,7 +76,6 @@ def call(String name = env.STAGE_NAME, cfg = null) {
   if( ! module_src )
     throw new MPLModuleException("Unable to find not active module to execute: ${(active_modules).join(' --> ')} -X> ${module_path}")
 
-  // Basically block_id is needed only for tests
   String block_id = MPLManager.instance.pushActiveModule(module_path)
   try {
     Helper.runModule(module_src, module_path, [CFG: cfg])

--- a/vars/MPLModulePostStep.groovy
+++ b/vars/MPLModulePostStep.groovy
@@ -31,5 +31,5 @@ import com.griddynamics.devops.mpl.MPLManager
  * @see MPLManager#modulePostStep(String name, Closure body)
  */
 def call(Closure body) {
-  MPLManager.instance.modulePostStep(MPLManager.instance.getActiveModules().last(), body)
+  MPLManager.instance.modulePostStep(null, body)
 }


### PR DESCRIPTION
fixes: #54

* Mapped the `activeModules` variable and logic to `Pipeline Steps` - now each particular thread will know it's parents and will work properly with parallel execution of the MPL modules.
* Improved view in the `Pipeline Steps` and console output - now MPL has it's own blocks to hide/show and see what kind of files was used as modules.
* Hid the MPLModule system steps (`fileExists` & `writeFile`) - now it uses identical functions that will not be shown in the console & `Pipeline Steps`.