### PR TITLE
MPL-64 CI: Updated maven tool version to fix the latest jenkins build

### DIFF
--- a/.circleci/jenkinsbro/config/jenkins.conf
+++ b/.circleci/jenkinsbro/config/jenkins.conf
@@ -21,7 +21,7 @@ modules {
       'Maven 3' {
         installers = [[
           name: 'Install from Apache',
-          params: ['3.6.1']
+          params: ['3.6.3']
         ]]
       }
     }


### PR DESCRIPTION
fixes: #64 