### PR TITLE
MPL-58 Fixed issue with using MPLPostStep directly in pipeline

### DIFF
--- a/src/com/griddynamics/devops/mpl/MPLManager.groovy
+++ b/src/com/griddynamics/devops/mpl/MPLManager.groovy
@@ -133,7 +133,8 @@ class MPLManager implements Serializable {
   public void postStep(String name, Closure body) {
     // TODO: Parallel execution - could be dangerous
     if( ! postSteps[name] ) postSteps[name] = []
-    postSteps[name] << [block: Helper.getMPLBlocks()?.first(), body: body]
+    def blocks = Helper.getMPLBlocks()
+    postSteps[name] << [block: blocks ? blocks.first() : null, body: body]
   }
 
   /**
@@ -149,7 +150,7 @@ class MPLManager implements Serializable {
     }
     // TODO: Parallel execution - could be dangerous
     if( ! modulePostSteps[name] ) modulePostSteps[name] = []
-    modulePostSteps[name] << [block: Helper.getMPLBlocks()?.first(), body: body]
+    modulePostSteps[name] << [block: Helper.getMPLBlocks().first(), body: body]
   }
 
   /**


### PR DESCRIPTION
The function `Helper.getMPLBlocks()` not returning null and not work properly in case `MPLPostStep()` is running directly from the pipeline.

Regarding `MPLManager.modulePostStep()` - it's not going to be executed as part of pipeline - only from the module, so no need to be changed - just changed the wrong `?.` to a proper `.`.

fixes: #58 