### PR TITLE
MPL-92 Switched to https schema for jenkins repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The schema change is required because the folks set permanent redirect which is fails deps download for the mpl build.

fixes: #92 