### PR TITLE
Prepared the new docker jenkins tester by using CASC & JenkinsBro tests module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,25 +87,19 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Get the jenkinsBro repo
-          command: git clone https://github.com/rabits/jenkinsbro ~/jenkinsbro
-
       - setup_remote_docker
           # CircleCI cache now not free
           # docker_layer_caching: true
 
       - run:
           name: Build jenkins image
-          command: ~/jenkinsbro/jenkinsbro_build.sh "<< parameters.jenkins_version >>"
+          command: docker build -t jenkinsbro --build-arg "JENKINS_VERSION=$(.circleci/get_jenkins_version.sh << parameters.jenkins_version >>)" .circleci/jenkins
           no_output_timeout: 5m
 
       - run:
-          name: Copy jenkinsbro configuration and tests
+          name: Create jenkins_home container to store data
           command: | # CircleCI using remote docker server - so we can't just mount the folder...
             docker create -v /var/jenkins_home --name jenkins-home alpine /bin/true
-            docker cp .circleci/jenkinsbro/config jenkins-home:/var/jenkins_home
-            docker cp .circleci/jenkinsbro/jenkinsBro jenkins-home:/var/jenkins_home
             docker run --rm -it --volumes-from jenkins-home alpine chown -R 1000:1000 /var/jenkins_home
 
       - run:
@@ -114,7 +108,8 @@ jobs:
             docker run -e "MPL_VERSION=$(echo "${CIRCLE_BRANCH}" | sed 's|\(pull/[0-9]*\)|\1/merged|g')"
             -e "MPL_REFSPEC=$(echo "${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}" | sed -e '/^pull/! s|\(.*\)|heads/\1|' -e 's|\(pull/[0-9]*\)|\1/merged|g')"
             -e "MPL_CLONE_URL=$(echo "${CIRCLE_REPOSITORY_URL}" | sed 's|git@github.com:|https://github.com/|')"
-            --name jenkins --rm -it --volumes-from jenkins-home jenkinsbro-master
+            -e "HTTP_PORT=8085"
+            --name jenkins --rm -it --volumes-from jenkins-home jenkinsbro
           no_output_timeout: 5m
 
       - run:
@@ -122,7 +117,7 @@ jobs:
           when: always
           command: |
             mkdir -p results/artifacts results/reports
-            docker cp jenkins-home:/var/jenkins_home/jenkinsBro/junit_report results/reports/junit
+            docker cp jenkins-home:/var/jenkins_home/junit_report results/reports/junit
             docker rm jenkins-home
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8u222-jdk-stretch
+      - image: circleci/openjdk:11-jdk
 
     working_directory: ~/repo
 
@@ -82,7 +82,7 @@ jobs:
         default: ""
         type: string
     docker:
-      - image: circleci/openjdk:8u222-jdk-stretch
+      - image: circleci/openjdk:11-jdk
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/get_jenkins_version.sh
+++ b/.circleci/get_jenkins_version.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Script to find of the lts/latest versions of jenkins
+#
+# Usage:
+#   $ ./jenkinsbro_build.sh <VERSION>
+#
+# Parameters:
+#   VERSION - allows to check the version to use, values:
+#     * "2.176."  - prefix of the jenkins version, will choose the latest available LTS 2.176.*
+#     * "2.176.2" - exact version you want
+#     * "lts"     - latest stable version
+#     * "latest"  - just latest version
+#
+
+VAR_VERSION=$1
+
+if [ -z "${VAR_VERSION}" ]; then
+    echo Specify the version you need
+    exit 1
+fi
+
+ver_url=https://mirrors.jenkins.io/war
+ver="[0-9]"
+if [ "${VAR_VERSION}" = 'lts' ]; then
+    ver_url=${ver_url}-stable
+elif [ "${VAR_VERSION}" != 'latest' ]; then
+    ver=$(echo "${VAR_VERSION}" | tr -dc '0-9.')
+    echo "Using specified version '${ver}'" 1>&2
+fi
+
+jenkins_version=$(curl -s "${ver_url}/" | grep -oE 'href="'${ver}'[^/]*' | head -1 | tr -dc '0-9.')
+if [ "x$jenkins_version" = "x" ]; then
+    echo "Unable to find version for: ${VAR_VERSION} '${jenkins_version}'" 1>&2
+    exit 1
+fi
+
+echo "${jenkins_version}"

--- a/.circleci/jenkins/Dockerfile
+++ b/.circleci/jenkins/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile to put plugins and other vars to the image
+ARG JENKINS_VERSION
+
+FROM jenkins/jenkins:${JENKINS_VERSION}-jdk11
+
+COPY --chown=jenkins:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
+
+ENV CASC_JENKINS_CONFIG=/usr/local/jenkins-casc \
+    CASC_GROOVY_TESTS_PATH=/usr/local/jenkins-tests \
+    JENKINS_HOSTNAME=localhost \
+    JAVA_OPTS="-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
+
+COPY --chown=root:jenkins jenkins-casc.yml ${CASC_JENKINS_CONFIG}/
+
+COPY --chown=root:jenkins tests ${CASC_GROOVY_TESTS_PATH}/

--- a/.circleci/jenkins/jenkins-casc.yml
+++ b/.circleci/jenkins/jenkins-casc.yml
@@ -1,0 +1,118 @@
+---
+# Jenkins server configuration
+
+jenkins:
+  systemMessage: Jenkins Environment
+
+  numExecutors: 1  # Should be 0 on prod envs
+
+  agentProtocols:
+    - JNLP4-connect
+    - Ping
+
+  # Proxy compatibility if using nginx
+  #crumbIssuer:
+  #  standard:
+  #    excludeClientIPGromCrumb: true
+
+  # Restricting agents in actions
+  remotingSecurity:
+    enabled: true
+
+  # Set local access restrictions
+  disableRememberMe: true
+
+#  securityRealm:
+#    local:
+#      allowsSignup: false
+#      users:
+#        # There could be only one
+#        - id: admin
+#          password: admin
+#        # To test the prod user access
+#        - id: user
+#          password: user
+#
+#  authorizationStrategy:
+#    globalMatrix:
+#      permissions:
+#        # In case needed to change the configs and see them in CASC export view
+#        - EITHER:Overall/Administer:admin
+#
+#        # Read only access for the user
+#        - EITHER:Agent/ExtendedRead:authenticated
+#        - EITHER:Credentials/View:authenticated
+#        - EITHER:Job/Build:authenticated
+#        - EITHER:Job/Cancel:authenticated
+#        - EITHER:Job/Configure:authenticated
+#        - EITHER:Job/Create:authenticated
+#        - EITHER:Job/Delete:authenticated
+#        - EITHER:Job/Move:authenticated
+#        - EITHER:Job/Read:authenticated
+#        - EITHER:Overall/Read:authenticated
+#        - EITHER:Overall/SystemRead:authenticated
+#        - EITHER:Run/Delete:authenticated
+#        - EITHER:Run/Update:authenticated
+#        - EITHER:View/Configure:authenticated
+#        - EITHER:View/Create:authenticated
+#        - EITHER:View/Delete:authenticated
+#        - EITHER:View/Read:authenticated
+
+unclassified:
+  location:
+    adminAddress: admin@localhost
+    url: http://${JENKINS_HOSTNAME}:${HTTP_PORT}/  # Actually better to use https
+
+  audit-trail:
+    logBuildCause: true
+    pattern: ".*/(?:configSubmit|doDelete|postBuildResult|enable|disable|cancelQueue|stop|toggleLogKeep|doWipeOutWorkspace|createItem|createView|toggleOffline|cancelQuietDown|quietDown|restart|exit|safeExit)/?.*"
+    loggers:
+      - logFile:
+          count: 30
+          limit: 1000
+          log: /var/jenkins_home/logs/audit.log
+          logSeparator: " "
+
+  globalLibraries:
+    libraries:
+      - name: mpl
+        defaultVersion: ${MPL_VERSION}
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                remote: ${MPL_CLONE_URL}
+                traits:
+                  - cloneOptionTrait:
+                      extension:
+                        honorRefspec: true
+                        noTags: false
+                        reference: ${MPL_REFSPEC}
+                        shallow: false
+
+tool:
+  git:
+    installations:
+      - name: Environment git client
+        home: git
+  maven:
+    installations:
+      - name: Maven 3
+        properties:
+          - installSource:
+              installers:
+                - maven:
+                    id: '3.6.3'
+
+
+# Run script with tests
+groovy:
+  - script: |
+      import jenkins.model.Jenkins
+
+      println('Running JenkinsBro test framework...')
+
+      GroovyShell shell = new GroovyShell(Jenkins.instance.getPluginManager().uberClassLoader, binding)
+      shell.evaluate(new File('/usr/local/jenkins-tests/tests.groovy'))
+
+      println('JenkinsBro test framework is running...')

--- a/.circleci/jenkins/plugins.txt
+++ b/.circleci/jenkins/plugins.txt
@@ -1,0 +1,10 @@
+ansicolor
+build-timeout
+git
+jobConfigHistory
+timestamper
+workflow-aggregator
+configuration-as-code
+configuration-as-code-groovy
+matrix-auth
+audit-trail

--- a/.circleci/jenkins/tests/lib/SimpleJUnitResultFormatterAsRunListener.groovy
+++ b/.circleci/jenkins/tests/lib/SimpleJUnitResultFormatterAsRunListener.groovy
@@ -1,0 +1,160 @@
+/**
+ * Class to convert test results to junit xml
+ */
+
+import junit.framework.Test
+import junit.framework.TestResult
+
+import org.junit.runner.notification.Failure
+import org.junit.runner.notification.RunListener
+import org.junit.runner.Description
+import org.junit.runner.Result
+
+/**
+ * Simple groovy implementation of the JUnitResultFormatterAsRunListener
+ * It also captures stdout/stderr by intercepting the likes of System#out.
+ */
+class SimpleJUnitResultFormatterAsRunListener extends RunListener {
+  private final File report_dir
+  private ByteArrayOutputStream stdout
+  private PrintStream old_stdout, old_stderr
+
+  private long test_start_time
+
+  private String suite_name
+  private String suite_timestamp
+  private int suite_error_count
+  private Map suite_results
+
+  SimpleJUnitResultFormatterAsRunListener(File report_dir) {
+    this.report_dir = report_dir
+  }
+
+  @Override
+  public void testRunStarted(Description description) throws Exception {
+    suite_name = description.getChildren()[0].toString()
+    suite_results = [:]
+    suite_timestamp = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone('UTC'))
+    println("Suite started: ${suite_name}, tests: ${description.testCount()}")
+  }
+
+  @Override
+  public void testStarted(Description description) throws Exception {
+    println('')
+    println("Test started: ${description.toString()}")
+    suite_results[description.toString()] = [
+      failures: [],
+      errors: [],
+    ]
+
+    test_start_time = System.currentTimeMillis()
+
+    // Capture the stdout/stderr
+    old_stdout = System.out
+    old_stderr = System.err
+    System.setOut(new PrintStream(stdout = new ByteArrayOutputStream()))
+    System.setErr(new PrintStream(stdout))
+  }
+
+  @Override
+  public void testIgnored(Description description) throws Exception {
+    println('')
+    println("Ignored test: ${description.toString()} - ${description.getAnnotation(org.junit.Ignore.class)?.value()}")
+    suite_results[description.toString()] = [
+      name: description.toString(),
+      skipped: true,
+      notice: description.getAnnotation(org.junit.Ignore.class).value(),
+      duration: 0,
+    ]
+  }
+
+  @Override
+  public void testFinished(Description description) throws Exception {
+    // Stop capture the stdout/stderr
+    System.out.flush()
+    System.err.flush()
+    System.setOut(old_stdout)
+    System.setErr(old_stderr)
+    println('')
+    println("Test finished: ${description.toString()}")
+
+    suite_results[description.toString()] += [
+      name: description.toString(),
+      stdout: stdout.toString(),
+      stderr: '',
+      duration: System.currentTimeMillis() - test_start_time,
+    ]
+  }
+
+  @Override
+  public void testFailure(Failure failure) throws Exception {
+    testAssumptionFailure(failure)
+  }
+
+  @Override
+  public void testAssumptionFailure(Failure failure) {
+    // Stop capture the stdout/stderr
+    System.out.flush()
+    System.err.flush()
+    System.setOut(old_stdout)
+    System.setErr(old_stderr)
+    println('')
+    println("Error found: ${failure.getDescription()}: ${failure.getException()}")
+    def e = failure.getException()
+    def key = e instanceof AssertionError ? 'failures' : 'errors'
+    suite_results[failure.getDescription().toString()][key] += e
+    if( key == 'errors' )
+      suite_error_count++
+
+    // Printing stdout on fail
+    println('-----8<----- LOG -----8<-----')
+    println(stdout.toString())
+    println('---->8---- END LOG ---->8----')
+  }
+
+  @Override
+  public void testRunFinished(Result result) throws Exception {
+    println('Suite finished')
+
+    // Write XML data to the report file
+    def writer = new StringWriter()
+    def xml = new groovy.xml.MarkupBuilder(writer)
+
+    xml.testsuites( disabled: result.getIgnoreCount(),
+                    errors: suite_error_count, failures: result.getFailureCount(),
+                    tests: result.getRunCount(), time: (result.getRunTime()/1000.0f).round(3) ) {
+      testsuite( name: suite_name,
+                 id: 0, disabled: result.getIgnoreCount(), skipped: result.getIgnoreCount(),
+                 errors: suite_error_count, failures: result.getFailureCount(),
+                 tests: result.getRunCount(), time: (result.getRunTime()/1000.0f).round(3), timestamp: suite_timestamp ) {
+        /*properties {
+          property( name: 'asd', value: 'dsd' )
+        }*/
+        suite_results.values().each { test ->
+          testcase( name: test.name, classname: suite_name, time: (test.duration/1000.0f).round(3) ) {
+            if( test.skipped ) {
+              skipped()
+            } else if( test.errors ) {
+              test.errors.each {
+                error( message: it.getMessage(), type: it.getClass().toString() )
+              }
+            } else if( test.failures ) {
+              test.failures.each {
+                failure( message: it.getMessage(), type: it.getClass().toString() )
+              }
+            }
+
+            if( test.stdout?.trim() )
+              'system-out'( test.stdout.trim() )
+            if( test.stderr?.trim() )
+              'system-err'( test.stderr.trim() )
+          }
+        }
+      }
+    }
+
+    def file = new File(report_dir, "TEST-${suite_name}.xml")
+    file.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+    file.append(writer.toString())
+  }
+}

--- a/.circleci/jenkins/tests/tests.groovy
+++ b/.circleci/jenkins/tests/tests.groovy
@@ -1,0 +1,104 @@
+/**
+ * Testing module
+ * Allows to run unit and integration tests on the working jenkins
+ * You can test how configuration was applied, run jobs/pipelines or UI tests
+ *
+ * Env vars:
+ *   CASC_GROOVY_TESTS_PATH - basic tests module dir which contains `tests` dir with test classes
+ *   JENKINS_HOME           - path to jenkins home directory
+ *
+ */
+
+// Need to get junit because jenkins 2.253 doesn't have it
+@Grab(group='junit', module='junit', version='4.13')
+
+import hudson.init.InitMilestone
+import jenkins.model.Jenkins
+
+/**
+ * Common test class
+ * You can use it in your tests
+ */
+class JenkinsTest {
+  def jenkins
+
+  @org.junit.Before
+  void setUp() {
+    jenkins = Jenkins.getInstance()
+  }
+}
+
+Thread.start('JenkinsBro tests') {
+  def tests_dir = "${System.getenv('CASC_GROOVY_TESTS_PATH')}/tests"
+  def status_file = new File("${System.getenv('JENKINS_HOME')}/tests_status")
+  status_file.write('Started')
+  def junit_report_dir = new File("${System.getenv('JENKINS_HOME')}/junit_report")
+  junit_report_dir.deleteDir()
+  junit_report_dir.mkdir()
+
+  def failed_tests = 0
+
+  println("JenkinsBro tests started, status file: `${status_file}`, reports dir: `${junit_report_dir}`")
+
+  try {
+    println('JenkinsBro tests: waiting for Jenkins initialization...')
+    def retries = 5 * 60 // 5 minutes
+    (1..retries).each {
+      if( Jenkins.getInstance().getInitLevel() == InitMilestone.COMPLETED )
+        return
+      sleep(1000)
+    }
+
+    if( Jenkins.getInstance().getInitLevel() != InitMilestone.COMPLETED )
+      return println("JenkinsBro tests, Jenkins initialization not completed in ${retries} seconds, exiting...")
+
+    println('JenkinsBro tests: loading required classes')
+    def cl = new GroovyClassLoader(this.class.getClassLoader())
+    cl.setClassCacheEntry(JenkinsTest)
+
+    println('JenkinsBro tests: preparing junit')
+    def core = org.junit.runner.JUnitCore.newInstance()
+    def listener = new org.junit.internal.TextListener(System.out)
+    core.addListener(listener)
+
+    cl.addClasspath("${System.getenv('CASC_GROOVY_TESTS_PATH')}/lib")
+    Class formatterClazz = cl.loadClass('SimpleJUnitResultFormatterAsRunListener')
+    core.addListener(formatterClazz.newInstance(junit_report_dir))
+
+    new File(tests_dir).eachFileRecurse(groovy.io.FileType.FILES) {
+      if( !it.name.endsWith('Test.groovy') )
+        return
+
+      println("Init test suite: ${it.getName()}...")
+      Class clazz
+
+      try {
+        clazz = cl.parseClass(it)
+      } catch( Exception ex ) {
+        println("ERROR: Exception while loading test suite ${it}: ${ex}")
+        return it.name
+      }
+
+      println("Running test suite: ${it.getName()}...")
+
+      try {
+        def result = core.run(clazz)
+        failed_tests += result.getFailureCount()
+      } catch( Exception ex ) {
+        println("ERROR: Exception while running test suite ${it}: ${ex}")
+        ex.printStackTrace()
+        return it.name
+      }
+    }
+  } catch( Exception ex ) {
+    println("ERROR: Exception while executing tests: ${ex}")
+    ex.printStackTrace()
+  }
+
+  status_file.write('Finished')
+
+  println('JenkinsBro tests: All tests are finished')
+
+  println('JenkinsBro tests: Shutdown Jenkins')
+  System.exit(failed_tests)
+}

--- a/.circleci/jenkins/tests/tests/MPLPipelineTest.groovy
+++ b/.circleci/jenkins/tests/tests/MPLPipelineTest.groovy
@@ -1,0 +1,37 @@
+/**
+ * MPL build using MPL
+ *
+ * Env vars:
+ *   MPL_CLONE_URL - where to get the sources
+ *   MPL_REFSPEC   - refspec mapping
+ *   MPL_VERSION   - branch/commit/tag to verify
+ */
+
+import hudson.plugins.git.*
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+
+import org.junit.Test
+
+class MPLPipelineTest extends JenkinsTest {
+  @Test
+  void testJenkinsfileBuild() {
+    println("Setup job configuration...")
+
+    def remote_configs = [new UserRemoteConfig(System.getenv('MPL_CLONE_URL'), null, System.getenv('MPL_REFSPEC'), '')]
+    def branches = [new BranchSpec(System.getenv('MPL_VERSION') ?: 'master')]
+    def scm = new GitSCM(remote_configs, branches, false, [], null, null, [])
+
+    def wfjob = jenkins.createProject(WorkflowJob.class, 'mpl-build')
+    def flow_def = org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.newInstance(scm, 'Jenkinsfile')
+    wfjob.setDefinition(flow_def)
+
+    println('Running the job and wait for complete')
+    def task_future = wfjob.scheduleBuild2(0)
+    def build = task_future.waitForStart()
+    task_future.get() // Waiting
+
+    build.getLogText().writeLogTo(0, System.out)
+
+    assert build.getResult().toString() == 'SUCCESS'
+  }
+}


### PR DESCRIPTION
The jenkinsbro I used previously to setup jenkins is quite obsolete so I rewrote the the jenkins docker tester to CASC plugin and a bit rewritten tests module of JenkinsBro.

The most important change is that tests now will print the job log output on test failure which is much more useful than going to junit test and look in it stdout.