### PR TITLE
MPL-102 Fixed issue with path processing when running server on Win

### DIFF
--- a/src/com/griddynamics/devops/mpl/Helper.groovy
+++ b/src/com/griddynamics/devops/mpl/Helper.groovy
@@ -181,7 +181,12 @@ abstract class Helper {
    */
   @NonCPS
   static String pathToSimpleName(String path) {
-    return path.tokenize('./')[-3,-2].join('/')
+    def p = new File(path)
+    def fname = p.getName().toString()
+    if( p.getParentFile() ) {
+      return [p.getParentFile().getName(), fname.take(fname.lastIndexOf('.'))].join('/')
+    }
+    return fname.take(fname.lastIndexOf('.'))
   }
 
   /**


### PR DESCRIPTION
This fix is for rare case of running Jenkins server on windows. The tokenization is not the great way of processing and expecting proper array items on the output was quite silly. So I rewrote the function to use File mechanism of parsing the paths - on *nix it will properly work with *nix paths and on windows it will properly process the windows paths.

fixes: #102 