### PR TITLE
Fixed CI failures

### DIFF
--- a/.circleci/get_jenkins_version.sh
+++ b/.circleci/get_jenkins_version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Script to find of the lts/latest versions of jenkins
+# Script to find of the lts/latest docker image version of jenkins
 #
 # Usage:
 #   $ ./jenkinsbro_build.sh <VERSION>
@@ -29,7 +29,8 @@ elif [ "${VAR_VERSION}" != 'latest' ]; then
     echo "Using specified version '${ver}'" 1>&2
 fi
 
-jenkins_version=$(curl -s "${ver_url}/" | grep -oE 'href="'${ver}'[^/]*' | head -1 | tr -dc '0-9.')
+# Get version-1 to not complicate the dockerhub checks - sometimes images are not here for the fresh versions
+jenkins_version=$(curl -s "${ver_url}/" | grep -oE 'href="'${ver}'[^/]*' | head -2 | tail -1 | tr -dc "0-9.\n")
 if [ "x$jenkins_version" = "x" ]; then
     echo "Unable to find version for: ${VAR_VERSION} '${jenkins_version}'" 1>&2
     exit 1

--- a/.circleci/jenkins/Dockerfile
+++ b/.circleci/jenkins/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to put plugins and other vars to the image
 ARG JENKINS_VERSION
 
-FROM jenkins/jenkins:${JENKINS_VERSION}-jdk11
+FROM jenkins/jenkins:${JENKINS_VERSION}
 
 COPY --chown=jenkins:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt

--- a/resources/com/griddynamics/devops/mpl/modules/Build/MavenBuild.groovy
+++ b/resources/com/griddynamics/devops/mpl/modules/Build/MavenBuild.groovy
@@ -4,5 +4,5 @@
 
 withEnv(["PATH+MAVEN=${tool(CFG.'maven.tool_version' ?: 'Maven 3')}/bin"]) {
   def settings = CFG.'maven.settings_path' ? "-s '${CFG.'maven.settings_path'}'" : ''
-  sh """mvn -B ${settings} -DargLine='-Xmx1024m -XX:MaxPermSize=1024m' clean install"""
+  sh """mvn -B ${settings} -DargLine='-Xmx1024m' clean install"""
 }


### PR DESCRIPTION
Docker plain version is pointing to the earliest jdk (and jdk11 is the past), so skipped specification.