### PR TITLE
Fixed CI for MPL by removing deprecated agentProtocols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ workflows:
       - build
       - jenkins_test:
           jenkins_version: lts
+      - jenkins_test:
+          jenkins_version: latest
 
   nightly_jenkins_test:
     triggers:

--- a/.circleci/jenkins/jenkins-casc.yml
+++ b/.circleci/jenkins/jenkins-casc.yml
@@ -6,10 +6,6 @@ jenkins:
 
   numExecutors: 1  # Should be 0 on prod envs
 
-  agentProtocols:
-    - JNLP4-connect
-    - Ping
-
   # Proxy compatibility if using nginx
   #crumbIssuer:
   #  standard:


### PR DESCRIPTION
Previous fix #110 was not enough, so I've added test on latest as well.